### PR TITLE
Separate cache-files for monitoring of multiple hosts/farms

### DIFF
--- a/libexec/check_zevenet_farm.pl
+++ b/libexec/check_zevenet_farm.pl
@@ -175,10 +175,6 @@ $mp->getopts;
 
 my $debug         = "true" if ( defined $mp->opts->debug );
 my $zapi_version  = "v4.0";
-my $cache         = "true";
-my $cache_file    = "/tmp/farm-cache";
-my $lock_cache    = "/tmp/farm-cache.lock";
-my $cache_tiemout = 60;
 my $host          = $mp->opts->host;
 my $farmname      = $mp->opts->farmname;
 my $port          = $mp->opts->port // 444;
@@ -186,6 +182,10 @@ my $zapikey       = $mp->opts->zapikey;
 my $timeout       = $mp->opts->timeout;
 my $maintenance   = "false";
 my $problem       = "false";
+my $cache         = "true";
+my $cache_file    = "/tmp/farm-cache-${host}";
+my $lock_cache    = "/tmp/farm-cache-${host}.lock";
+my $cache_tiemout = 60;
 
 # Get a summary of connections and configuration for all farms in the system.
 # https://www.zevenet.com/zapidocv4.0/#show-farms-statistics

--- a/libexec/check_zevenet_farm_backend.pl
+++ b/libexec/check_zevenet_farm_backend.pl
@@ -175,10 +175,6 @@ $mp->getopts;
 
 my $debug         = "true" if ( defined $mp->opts->debug );
 my $zapi_version  = "v4.0";
-my $cache         = "true";
-my $cache_file    = "/tmp/backend-cache";
-my $lock_cache    = "/tmp/backend-cache.lock";
-my $cache_tiemout = 60;
 my $host          = $mp->opts->host;
 my $farmname      = $mp->opts->farmname;
 my $port          = $mp->opts->port // 444;
@@ -186,6 +182,10 @@ my $zapikey       = $mp->opts->zapikey;
 my $timeout       = $mp->opts->timeout;
 my $service_id    = $mp->opts->service;
 my $maintenance   = "false";
+my $cache         = "true";
+my $cache_file    = "/tmp/backend-cache-${host}-${farmname}";
+my $lock_cache    = "/tmp/backend-cache-${host}-${farmname}.lock";
+my $cache_tiemout = 60;
 
 # Shows the current farm status, their backend status and connections. Each farm will response with a different object, depending on the profile.
 # https://www.zevenet.com/zapidocv4.0/#show-farm-statistics


### PR DESCRIPTION
With static cache files the farm check does not work with multiple hosts as it might read the cache file from other farms and does not find the farm in question.

Also the backend check might report data for the wrong farm when using static cache files so I included both farm name and host in the file name. 